### PR TITLE
Wrap text

### DIFF
--- a/codePrint/prism.css
+++ b/codePrint/prism.css
@@ -12,7 +12,7 @@ pre[class*="language-"] {
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 	text-align: left;
-	white-space: pre;
+	white-space: pre-wrap;
 	word-spacing: normal;
 	word-break: normal;
 	word-wrap: break-word;


### PR DESCRIPTION
Long text when using AP PT CodePrint can get cut off when printed without wrapping it with `white-space: pre-wrap;`.